### PR TITLE
README: Lowercase -m argument

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,13 +8,13 @@ This utility will download the IB Java client code from [here](http://interactiv
 
 To use:
 ```
-clj -Sdeps '{:deps {tws-install/tws-install {:git/url "https://github.com/jjttjj/tws-install.git" :sha "76cb2184155eb1a08a35232aceb2d686739d419f"}}}' -M tws-install
+clj -Sdeps '{:deps {tws-install/tws-install {:git/url "https://github.com/jjttjj/tws-install.git" :sha "76cb2184155eb1a08a35232aceb2d686739d419f"}}}' -m tws-install
 
 ```
 
 Or, with powershell:
 ```
-clj -Sdeps '{:deps {tws-install/tws-install {:git/url ""https://github.com/jjttjj/tws-install.git"" :sha ""76cb2184155eb1a08a35232aceb2d686739d419f""}}}' -M tws-install
+clj -Sdeps '{:deps {tws-install/tws-install {:git/url ""https://github.com/jjttjj/tws-install.git"" :sha ""76cb2184155eb1a08a35232aceb2d686739d419f""}}}' -m tws-install
 
 ```
 


### PR DESCRIPTION
Changes the `-M` flag for clj to `-m. The command given in the upstream readme fails with:
```
 % clj -Sdeps '{:deps {tws-install/tws-install {:git/url "https://github.com/jjttjj/tws-install.git" :sha "76cb2184155eb1a08a35232aceb2d686739d419f"}}}' -M tws-install
Missing required argument for "-M ALIASES"
```

Lowercase `-m` seems to work.